### PR TITLE
fix: type error in _apply_platform

### DIFF
--- a/elk.bzl
+++ b/elk.bzl
@@ -395,7 +395,8 @@ def _uv_workspace_member(*, name: str, deps: dict, root: str, src_root: str, ver
 # Target creation
 # ---------------------------------------------------------------------------
 
-def _apply_platform(platforms: dict, platform_dict: dict, default: str):
+def _apply_platform(platforms, platform_dict: dict, default: str):
+    # no idea how to annotate platforms as possibly being a select
     return selects.apply(
         platforms,
         lambda platform: platform_dict.get(platform, default),


### PR DESCRIPTION
This might be because our buck2 is old, I have no idea. I just deleted the type annotation about it. Sorry if this is not especially reproducible, reproing the bug against newer buck2 might require doing a bunch of rebasing :(

//third_party/pypi/BUCK:

```python
"""
See ./pyproject.toml for the list of packages to generate into the buck2 set.
"""

load("@elk//:elk.bzl", "elk_packages", "uv_deps", "uv_packages")
load(":linux-x86_64.tags.json", linux_x86_64_tags = "value")
load(":macos-arm64.tags.json", macos_arm64_tags = "value")
load(":linux-arm64.tags.json", linux_arm64_tags = "value")
# This has an annoying caching bug: https://github.com/facebook/buck2/pull/1286
load(":uv.lock.toml", lock = "value")

elk_packages(
    packages = uv_packages(lock),
    # Tags generated with `buck2 run elk//tools:save_tags -- linux_x86_64.tags.json`.
    platform_tags = {
        "linux-x86_64": linux_x86_64_tags,
        "linux-arm64": linux_arm64_tags,
        "macos-arm64": macos_arm64_tags,
    },
)
```

```
BUILD FAILED
Error evaluating build file: `root//third_party/pypi:BUCK`

Caused by:
    Traceback (most recent call last):
      * third_party/pypi/BUCK:8, in <module>
          elk_packages(
      * elk/elk.bzl:517, in elk_packages
          actual = _apply_platform(platforms, actual_map, ":_elk_null")
    error: Value `select({"DEFAULT": None, "prelude//os:linux": select({"DEFAULT": None, "prelude//cpu:arm64": "linux-arm64", "prelude//cpu:riscv64": "linux-riscv64", "prelude//cpu:
x86_64": "linux-x86_64"}), "prelude//os:macos": select({"DEFAULT": None, "prelude//cpu:arm64": "macos-arm64", "prelude//cpu:x86_64": "macos-x86_64"}), "prelude//os:none": select({"D
EFAULT": None, "prelude//cpu:wasm32": "wasm32"}), "prelude//os:wasi": select({"DEFAULT": None, "prelude//cpu:wasm32": "wasi"}), "prelude//os:windows": select({"DEFAULT": "windows-ms
vc", "prelude//abi:gnu": "windows-gnu", "prelude//abi:msvc": "windows-msvc"})})` of type `Select` does not match the type annotation `dict` for argument `platforms`
       --> elk/elk.bzl:517:22
        |
    517 |             actual = _apply_platform(platforms, actual_map, ":_elk_null")
        |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
```